### PR TITLE
Specify GTK3 and update icons

### DIFF
--- a/Hantek.glade
+++ b/Hantek.glade
@@ -22,22 +22,22 @@
   <object class="GtkImage" id="Start1">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="stock">gtk-media-play</property>
+    <property name="icon-name">media-playback-start</property>
   </object>
   <object class="GtkImage" id="Start2">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="stock">gtk-media-play</property>
+    <property name="icon-name">media-playback-start</property>
   </object>
   <object class="GtkImage" id="Stop1">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="stock">gtk-media-stop</property>
+    <property name="icon-name">media-playback-stop</property>
   </object>
   <object class="GtkImage" id="Stop2">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="stock">gtk-media-stop</property>
+    <property name="icon-name">media-playback-stop</property>
   </object>
   <object class="GtkAdjustment" id="awg_amp_adj">
     <property name="upper">2.5</property>

--- a/Hantek.py
+++ b/Hantek.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass, field
 
 import usb.core
 import usb.util
+import gi
+
+gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Require GTK 3 explicitly in code to avoid loading GTK 4
- Replace deprecated stock icons with modern icon names

## Testing
- `python -m py_compile Hantek.py`
- `xvfb-run -a gtk-builder-tool validate Hantek.glade`


------
https://chatgpt.com/codex/tasks/task_e_68b4aaac17f4832981b18a9b420c15de